### PR TITLE
Add `localIdentName` to CSS Loader

### DIFF
--- a/src/distributor.js
+++ b/src/distributor.js
@@ -27,10 +27,10 @@ const compiler = webpack({
       },
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style', 'css?modules!sass'),
+        loader: ExtractTextPlugin.extract('style', 'css?modules&localIdentName=[name]__[local]___[hash:base64:5]!sass'),
       },
     ],
-  },
+  },\
   plugins: [
     new ExtractTextPlugin('styles.css'),
     new webpack.optimize.UglifyJsPlugin({

--- a/src/distributor.js
+++ b/src/distributor.js
@@ -74,6 +74,6 @@ export default function distribute() {
       handleWarnings(jsonStats.warnings);
     }
 
-    return console.log('Successfully wrote to bundle.js');
+    return console.log('Successfully wrote to bundle.js and styles.css');
   });
 }

--- a/src/distributor.js
+++ b/src/distributor.js
@@ -30,7 +30,7 @@ const compiler = webpack({
         loader: ExtractTextPlugin.extract('style', 'css?modules&localIdentName=[name]__[local]___[hash:base64:5]!sass'),
       },
     ],
-  },\
+  },
   plugins: [
     new ExtractTextPlugin('styles.css'),
     new webpack.optimize.UglifyJsPlugin({

--- a/src/server.js
+++ b/src/server.js
@@ -46,7 +46,7 @@ const compiler = webpack({
       },
       {
         test: /\.scss$/,
-        loaders: ['style', 'css?modules', 'sass'],
+        loaders: ['style', 'css?modules&localIdentName=[name]__[local]___[hash:base64:5]', 'sass'],
       },
     ],
   },
@@ -124,4 +124,3 @@ function createEntryFile() {
 export default function run() {
   createEntryFile().then(() => runServer()).catch(err => console.log(err));
 }
-


### PR DESCRIPTION
Followed the example on the CSS Modules repo https://github.com/css-modules/webpack-demo

localIndentName is documented here https://github.com/webpack/css-loader.

Why did I not add the `importLoaders=1` that’s in the CSS Modules repo?

Because it’s not needed right now as there is no loaders after the CSS Loader. I don’t know why they add it either. Maybe just to highlight the feature’s available.  It’s documented here https://github.com/webpack/css-loader.