### PR TITLE
Add fe-brary-globals to default HTML

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,9 @@
 <html>
+  <head>
+    <link href="https://static.domain.com.au/content/web/agency/fe-brary-globals-3-2-5.css" media="all" rel="stylesheet">
+  </head>
   <body>
     <div class="app"></div>
     <script src="http://localhost:3000/bundle.js"></script>
   </body>
 </html>
-


### PR DESCRIPTION
This could be improved. We need a latest endpoint on the CDN so it’s always pulling the latest version. Feel free to boy this PR. A work around is to not use the default HTML template and create a custom one.