### PR TITLE
Exclude dependency folders from using the Babel loader

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -26,6 +26,7 @@ function generateWebpackCompiler(entryPath) {
       loaders: [
         {
           test: /\.js?$/,
+          exclude: /(node_modules|bower_components)/,
           loader: 'babel',
           query: {
             presets: ['react', 'es2015'],


### PR DESCRIPTION
See https://github.com/babel/babel-loader#usage.